### PR TITLE
Fix directory not found error when using .net core

### DIFF
--- a/src/EmptyFiles.Tests/Tests.cs
+++ b/src/EmptyFiles.Tests/Tests.cs
@@ -1,6 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Reflection;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
@@ -54,6 +56,94 @@ public class Tests :
         await WriteCategory(writer, "Sheet", EmptyFiles.SheetPaths);
         await WriteCategory(writer, "Slide", EmptyFiles.SlidePaths);
     }
+    
+	#region Empty Files Directory Tests
+
+	/// <summary>
+	/// The 'EmptyFiles' directory and assembly are copies and referenced in the same folder. 
+	/// </summary>
+	/// <remarks>
+	/// This would typically be in the same folder as the starting assembly.
+	/// </remarks>
+	[Fact]
+	public void EmptyFilesDirectoryStandardDeployment()
+	{
+		try
+		{
+			var result = CallGetEmptyFilesDirectory(_currentDirectory);
+			Assert.Equal(Path.Combine(_currentDirectory, "EmptyFiles"), result);
+		}
+		catch (DirectoryNotFoundException e)
+		{
+			Assert.True(false, "'EmptyFiles' directory was not where it was expected to be.  " + e.Message);
+		}
+	}
+	
+	/// <summary>
+	/// The 'EmptyFiles' directory is in the parent folder from where the assembly is referenced from. 
+	/// </summary>
+	/// <remarks>
+	/// This could happen if the 'EmptyFiles' assembly is being referenced and accessed directly from
+	/// a nuget package directory, and the 'EmptyFiles' directory is at the root of the package directory
+	/// and the assembly is in ./lib/{target Framework}/.
+	/// </remarks>
+	[Fact]
+	public void EmptyFilesDirectoryNugetDeployment()
+	{
+		try
+		{
+			var result = CallGetEmptyFilesDirectory(Path.Combine(_currentDirectory, ".\\tmp1\\tmp2"));
+			Assert.Equal(Path.Combine(_currentDirectory, "EmptyFiles"), result);
+		}
+		catch (DirectoryNotFoundException e)
+		{
+			Assert.True(false, "'EmptyFiles' directory was not where it was expected to be.  " + e.Message);
+		}
+	}
+
+	/// <summary>
+	/// The 'EmptyFiles' directory and assembly are not present, ensure we throw the correct error. 
+	/// </summary>
+	/// <remarks>
+	/// This would typically be in the same folder as the starting assembly.
+	/// </remarks>
+	[Fact]
+	public void EmptyFilesDirectoryMissing()
+	{
+		Assert.Throws<DirectoryNotFoundException>(() =>
+			CallGetEmptyFilesDirectory(Path.Combine(_currentDirectory, "tmp1/tmp2/tmp3/tmp4")));
+	}
+    
+	private static string? CallGetEmptyFilesDirectory(string currentDirectory)
+	{
+		var methodInfo = typeof(EmptyFiles).GetMethod("GetEmptyFilesDirectory", BindingFlags.Static | BindingFlags.NonPublic);
+		if (methodInfo == null)
+			throw new NullReferenceException("GetEmptyFilesDirectory method was not found on EmptyFiles");
+
+		try
+		{
+			return methodInfo.Invoke(null, new object[] { currentDirectory }) as string;
+		}
+		catch (TargetInvocationException e)
+		{
+			// Unwrap any TargetInvocationException.
+			while (e.InnerException is TargetInvocationException exception)
+			{
+				e = exception;
+			}
+
+			// Rethrow the DirectoryNotFoundException.
+			if (e.InnerException is DirectoryNotFoundException directoryNotFound)
+			{
+				throw e.InnerException;
+			}
+
+			// Rethrow the original
+			throw;
+		}
+	}
+
+	#endregion
 
     private static async Task WriteCategory(StreamWriter writer, string category, IEnumerable<string> allPaths)
     {
@@ -66,9 +156,22 @@ public class Tests :
             await writer.WriteLineAsync($"  * {ext} ({size})");
         }
     }
+    
+    private readonly string _currentDirectory = string.Empty;
 
     public Tests(ITestOutputHelper output) :
         base(output)
     {
+	    var assembly = typeof(Tests).Assembly;
+	    if (assembly.CodeBase != null)
+	    {
+		    var path = assembly.CodeBase
+			    .Replace("file:///", "")
+			    .Replace("file://", "")
+			    .Replace(@"file:\\\", "")
+			    .Replace(@"file:\\", "");
+
+		    _currentDirectory = Path.GetDirectoryName(path) ?? SourceDirectory;
+	    }
     }
 }

--- a/src/EmptyFiles/EmptyFiles.cs
+++ b/src/EmptyFiles/EmptyFiles.cs
@@ -12,23 +12,10 @@ public static class EmptyFiles
     public static Dictionary<string, EmptyFile> Images = new Dictionary<string, EmptyFile>();
     public static Dictionary<string, EmptyFile> Sheets = new Dictionary<string, EmptyFile>();
     public static Dictionary<string, EmptyFile> Slides = new Dictionary<string, EmptyFile>();
-
+    
     static EmptyFiles()
     {
-        var emptyFiles = Path.Combine(CodeBaseLocation.CurrentDirectory, "EmptyFiles");
-
-        if(!Directory.Exists(emptyFiles))
-        {
-            // When referenced from NuGet and run in a unit test with .net Core,
-            // CodeBaseLocation.CurrentDirectory can return the location of this assembly
-            // from with-in the package directory.  Look into the root of the package directory
-            // to see if the EmptyFile directory is there.
-            emptyFiles = Path.Combine(CodeBaseLocation.CurrentDirectory, "../../EmptyFiles");
-        }
-
-        if (!Directory.Exists(emptyFiles))
-            // Throw a detailed error message so people can quickly fix the missing files.
-            throw new DirectoryNotFoundException($"Could not find 'Empty Files' at path '{Path.Combine(CodeBaseLocation.CurrentDirectory, "EmptyFiles")}', ensure files are copied correctly.");
+	    var emptyFiles = GetEmptyFilesDirectory(CodeBaseLocation.CurrentDirectory);
 
         foreach (var file in Directory.EnumerateFiles(emptyFiles, "*.*", SearchOption.AllDirectories))
         {
@@ -56,6 +43,26 @@ public static class EmptyFiles
                     break;
             }
         }
+    }
+    
+	static string GetEmptyFilesDirectory(string currentDirectory)
+    {
+	    var emptyFiles = Path.GetFullPath(Path.Combine(currentDirectory, "EmptyFiles"));
+
+	    if(!Directory.Exists(emptyFiles))
+	    {
+		    // When referenced from NuGet and run in a unit test with .net Core,
+		    // CodeBaseLocation.CurrentDirectory can return the location of this assembly
+		    // from with-in the package directory.  Look into the root of the package directory
+		    // to see if the EmptyFile directory is there.
+		    emptyFiles = Path.GetFullPath(Path.Combine(currentDirectory, "../../EmptyFiles"));
+	    }
+
+	    if (!Directory.Exists(emptyFiles))
+		    // Throw a detailed error message so people can quickly fix the missing files.
+		    throw new DirectoryNotFoundException($"Could not find 'Empty Files' at path '{Path.Combine(currentDirectory, "EmptyFiles")}', ensure files are copied correctly.");
+
+	    return emptyFiles;
     }
 
     static EmptyFileCategory GetCategory(string file)

--- a/src/EmptyFiles/EmptyFiles.cs
+++ b/src/EmptyFiles/EmptyFiles.cs
@@ -26,9 +26,9 @@ public static class EmptyFiles
             emptyFiles = Path.Combine(CodeBaseLocation.CurrentDirectory, "../../EmptyFiles");
         }
 
-        if(!Directory.Exists(emptyFiles))
+        if (!Directory.Exists(emptyFiles))
             // Throw a detailed error message so people can quickly fix the missing files.
-            throw new DirectoryNotFoundException($"{Path.Combine(CodeBaseLocation.CurrentDirectory, "EmptyFiles")} not found");
+            throw new DirectoryNotFoundException($"Could not find 'Empty Files' at path '{Path.Combine(CodeBaseLocation.CurrentDirectory, "EmptyFiles")}', ensure files are copied correctly.");
 
         foreach (var file in Directory.EnumerateFiles(emptyFiles, "*.*", SearchOption.AllDirectories))
         {

--- a/src/EmptyFiles/EmptyFiles.cs
+++ b/src/EmptyFiles/EmptyFiles.cs
@@ -16,6 +16,20 @@ public static class EmptyFiles
     static EmptyFiles()
     {
         var emptyFiles = Path.Combine(CodeBaseLocation.CurrentDirectory, "EmptyFiles");
+
+        if(!Directory.Exists(emptyFiles))
+        {
+            // When referenced from NuGet and run in a unit test with .net Core,
+            // CodeBaseLocation.CurrentDirectory can return the location of this assembly
+            // from with-in the package directory.  Look into the root of the package directory
+            // to see if the EmptyFile directory is there.
+            emptyFiles = Path.Combine(CodeBaseLocation.CurrentDirectory, "../../EmptyFiles");
+        }
+
+        if(!Directory.Exists(emptyFiles))
+            // Throw a detailed error message so people can quickly fix the missing files.
+            throw new DirectoryNotFoundException($"{Path.Combine(CodeBaseLocation.CurrentDirectory, "EmptyFiles")} not found");
+
         foreach (var file in Directory.EnumerateFiles(emptyFiles, "*.*", SearchOption.AllDirectories))
         {
             var lastWriteTime = File.GetLastWriteTime(file);


### PR DESCRIPTION
Had an issue where I was getting this error message when calling into EmptyFiles.EmptyFiles

> System.TypeInitializationException : The type initializer for 'EmptyFiles' threw an exception.
  ----> System.IO.DirectoryNotFoundException : Could not find a part of the path 'C:\Users\MyUser\\.nuget\packages\emptyfiles\0.7.0\lib\netstandard2.0\EmptyFiles'.
   at EmptyFiles.TryGetPathFor(String extension, String& path) in C:\projects\emptyfiles\src\EmptyFiles\EmptyFiles.cs:line 108

Setup:

- Using VS 2019 (v 16.5.0)
- Resharper (v 2019.3.4)
- NUnit 3.12.0
- ApprovalTest 4.5.1 (this is what was referencing EmptyFiles)
- Project target framework: .NET Core 2.2

Repo Steps:

- Created a new unit test, using ApproalTest
- Run the unit test in debug mode via Resharper VS Test running

This PR will allow this scenario to work correctly.

And if the directory is still missing you now get the following error.

>System.TypeInitializationException : The type initializer for 'EmptyFiles' threw an exception.
  ----> System.IO.DirectoryNotFoundException : Could not find 'Empty Files' at path 'C:\Users\MyUser\\.nuget\packages\emptyfiles\0.7.0\lib\netstandard2.0\EmptyFiles', ensure files are copied correctly.
   at EmptyFiles.TryGetPathFor(String extension, String& path) in C:\Code\EmptyFiles\src\EmptyFiles\EmptyFiles.cs:line 121